### PR TITLE
Fixed I2C 7-Bit Addressing

### DIFF
--- a/STM32F10x_StdPeriph_Driver/src/stm32f10x_i2c.c
+++ b/STM32F10x_StdPeriph_Driver/src/stm32f10x_i2c.c
@@ -608,13 +608,17 @@ void I2C_Send7bitAddress(I2C_TypeDef* I2Cx, uint8_t Address, uint8_t I2C_Directi
   /* Test on the direction to set/reset the read/write bit */
   if (I2C_Direction != I2C_Direction_Transmitter)
   {
-    /* Set the address bit0 for read */
-    Address |= OAR1_ADD0_Set;
+	/* Shift the address one bit to the left */
+	Address = Address << 1;
+	/* Set the address bit0 for read */
+	Address |= OAR1_ADD0_Set;
   }
   else
   {
-    /* Reset the address bit0 for write */
-    Address &= OAR1_ADD0_Reset;
+	/* Shift the address one bit to the left */
+	Address = Address << 1;
+	/* Reset the address bit0 for write */
+	Address &= OAR1_ADD0_Reset;
   }
   /* Send the address */
   I2Cx->DR = Address;


### PR DESCRIPTION
The TwoWire Library expects slave addresses to be entered in the
standard 7-Bit format. Added some code to the I2C_Send7bitAddress
function so that the address is bitshift to the left by one, before
performing the bitwise operation to set the R/W bit. See: https://community.sparkdevices.com/t/i2c-7-or-8-bit-addresses/1328/9
