### PR TITLE
Cleanup the sFLASH driver

### DIFF
--- a/SPARK_Firmware_Driver/inc/platform_config.h
+++ b/SPARK_Firmware_Driver/inc/platform_config.h
@@ -219,7 +219,7 @@
 #define sFLASH_MEM_CS_GPIO_PORT				GPIOB						/* GPIOB */
 #define sFLASH_MEM_CS_GPIO_CLK				RCC_APB2Periph_GPIOB
 
-#define sFLASH_SPI_BAUDRATE_PRESCALER		SPI_BaudRatePrescaler_4
+#define sFLASH_SPI_BAUDRATE_PRESCALER		SPI_BaudRatePrescaler_2
 
 #define USB_DISCONNECT_PIN               	GPIO_Pin_10
 #define USB_DISCONNECT_GPIO_PORT       		GPIOB

--- a/SPARK_Firmware_Driver/inc/sst25vf_spi.h
+++ b/SPARK_Firmware_Driver/inc/sst25vf_spi.h
@@ -54,25 +54,23 @@
 #define sFLASH_SST25VF040_ID			0xBF258D	/* JEDEC Read-ID Data */
 #define sFLASH_SST25VF016_ID			0xBF2541	/* JEDEC Read-ID Data */
 
-/* High layer functions */
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+/* High level functions. */
 void sFLASH_Init(void);
 void sFLASH_EraseSector(uint32_t SectorAddr);
 void sFLASH_EraseBulk(void);
-void sFLASH_WriteByte(uint32_t WriteAddr, uint8_t byte);
-void sFLASH_WritePage(uint8_t* pBuffer, uint32_t WriteAddr, uint16_t NumByteToWrite);
-void sFLASH_WriteBuffer(uint8_t* pBuffer, uint32_t WriteAddr, uint16_t NumByteToWrite);
-void sFLASH_ReadBuffer(uint8_t* pBuffer, uint32_t ReadAddr, uint16_t NumByteToRead);
+void sFLASH_WriteBuffer(uint8_t *pBuffer, uint32_t WriteAddr, uint32_t NumByteToWrite);
+void sFLASH_ReadBuffer(uint8_t *pBuffer, uint32_t ReadAddr, uint32_t NumByteToRead);
 uint32_t sFLASH_ReadID(void);
-
-/* Low layer functions */
-uint8_t sFLASH_SendByte(uint8_t byte);
-void sFLASH_WriteEnable(void);
-void sFLASH_WriteDisable(void);
-void sFLASH_WaitForWriteEnd(void);
 
 /* Flash Self Test Routine */
 int sFLASH_SelfTest(void);
 
-extern void Delay(__IO uint32_t nTime);
+#ifdef __cplusplus
+} /* extern "C" */
+#endif /* __cplusplus */
 
 #endif /* __SST25VF_SPI_H */

--- a/SPARK_Firmware_Driver/src/sst25vf_spi.c
+++ b/SPARK_Firmware_Driver/src/sst25vf_spi.c
@@ -247,8 +247,11 @@ void sFLASH_WriteBuffer(uint8_t *pBuffer, uint32_t WriteAddr, uint32_t NumByteTo
   /* Write bulk of bytes using auto increment write, with restriction
    * that address must always be even and two bytes are written at a time. */
   evenBytes = NumByteToWrite & ~0x1;
-  sFLASH_WriteBytes(pBuffer, WriteAddr, evenBytes);
-  NumByteToWrite -= evenBytes;
+  if (evenBytes)
+  {
+    sFLASH_WriteBytes(pBuffer, WriteAddr, evenBytes);
+    NumByteToWrite -= evenBytes;
+  }
 
   /* If number of bytes to write is odd, need to use a single byte write
    * to write the last address. */

--- a/SPARK_Firmware_Driver/src/sst25vf_spi.c
+++ b/SPARK_Firmware_Driver/src/sst25vf_spi.c
@@ -27,6 +27,14 @@
 /* Includes ------------------------------------------------------------------*/
 #include "sst25vf_spi.h"
 
+/* Local function forward declarations ---------------------------------------*/
+static void sFLASH_WriteByte(uint32_t WriteAddr, uint8_t byte);
+static void sFLASH_WriteBytes(uint8_t *pBuffer, uint32_t WriteAddr, uint32_t NumByteToWrite);
+static void sFLASH_WriteEnable(void);
+static void sFLASH_WriteDisable(void);
+static void sFLASH_WaitForWriteEnd(void);
+static uint8_t sFLASH_SendByte(uint8_t byte);
+
 /**
   * @brief Initializes SPI Flash
   * @param void
@@ -123,11 +131,12 @@ void sFLASH_EraseBulk(void)
 
 /**
   * @brief  Write one byte to the FLASH.
+  * @note   Addresses to be written must be in the erased state
   * @param  WriteAddr: FLASH's internal address to write to.
   * @param  byte: the data to be written.
   * @retval None
   */
-void sFLASH_WriteByte(uint32_t WriteAddr, uint8_t byte)
+static void sFLASH_WriteByte(uint32_t WriteAddr, uint8_t byte)
 {
   /* Enable the write access to the FLASH */
   sFLASH_WriteEnable();
@@ -152,15 +161,16 @@ void sFLASH_WriteByte(uint32_t WriteAddr, uint8_t byte)
 
 /**
   * @brief  Writes more than one byte to the FLASH.
-  * @note   The number of bytes can't exceed the FLASH page size.
+  * @note   The address must be even and the number of bytes must be a multiple
+  *         of two.
+  * @note   Addresses to be written must be in the erased state
   * @param  pBuffer: pointer to the buffer containing the data to be written
   *         to the FLASH.
-  * @param  WriteAddr: FLASH's internal address to write to.
-  * @param  NumByteToWrite: number of bytes to write to the FLASH, must be even,
-  *         equal or less than "sFLASH_PAGESIZE" value.
+  * @param  WriteAddr: FLASH's internal address to write to, must be even.
+  * @param  NumByteToWrite: number of bytes to write to the FLASH, must be even.
   * @retval None
   */
-void sFLASH_WritePage(uint8_t* pBuffer, uint32_t WriteAddr, uint16_t NumByteToWrite)
+static void sFLASH_WriteBytes(uint8_t *pBuffer, uint32_t WriteAddr, uint32_t NumByteToWrite)
 {
   /* Enable the write access to the FLASH */
   sFLASH_WriteEnable();
@@ -214,80 +224,39 @@ void sFLASH_WritePage(uint8_t* pBuffer, uint32_t WriteAddr, uint16_t NumByteToWr
 
 /**
   * @brief  Writes block of data to the FLASH.
+  * @note   Addresses to be written must be in the erased state
   * @param  pBuffer: pointer to the buffer  containing the data to be written
   *         to the FLASH.
   * @param  WriteAddr: FLASH's internal address to write to.
   * @param  NumByteToWrite: number of bytes to write to the FLASH.
   * @retval None
   */
-void sFLASH_WriteBuffer(uint8_t* pBuffer, uint32_t WriteAddr, uint16_t NumByteToWrite)
+void sFLASH_WriteBuffer(uint8_t *pBuffer, uint32_t WriteAddr, uint32_t NumByteToWrite)
 {
-  uint8_t NumOfPage = 0, NumOfSingle = 0, Addr = 0, count = 0, temp = 0;
+  uint32_t evenBytes;
 
-  Addr = WriteAddr % sFLASH_PAGESIZE;
-  count = sFLASH_PAGESIZE - Addr;
-  NumOfPage =  NumByteToWrite / sFLASH_PAGESIZE;
-  NumOfSingle = NumByteToWrite % sFLASH_PAGESIZE;
-
-  if (Addr == 0) /* WriteAddr is sFLASH_PAGESIZE aligned  */
+  /* If write starts at an odd address, need to use single byte write
+   * to write the first address. */
+  if (WriteAddr & 0x1 == 0x1)
   {
-    if (NumOfPage == 0) /* NumByteToWrite < sFLASH_PAGESIZE */
-    {
-      sFLASH_WritePage(pBuffer, WriteAddr, NumByteToWrite);
-    }
-    else /* NumByteToWrite > sFLASH_PAGESIZE */
-    {
-      while (NumOfPage--)
-      {
-        sFLASH_WritePage(pBuffer, WriteAddr, sFLASH_PAGESIZE);
-        WriteAddr +=  sFLASH_PAGESIZE;
-        pBuffer += sFLASH_PAGESIZE;
-      }
-
-      sFLASH_WritePage(pBuffer, WriteAddr, NumOfSingle);
-    }
+    sFLASH_WriteByte(WriteAddr, *pBuffer++);
+    ++WriteAddr;
+    --NumByteToWrite;
   }
-  else /* WriteAddr is not sFLASH_PAGESIZE aligned  */
+
+  /* Write bulk of bytes using auto increment write, with restriction
+   * that address must always be even and two bytes are written at a time. */
+  evenBytes = NumByteToWrite & ~0x1;
+  sFLASH_WriteBytes(pBuffer, WriteAddr, evenBytes);
+  NumByteToWrite -= evenBytes;
+
+  /* If number of bytes to write is odd, need to use a single byte write
+   * to write the last address. */
+  if (NumByteToWrite)
   {
-    if (NumOfPage == 0) /* NumByteToWrite < sFLASH_PAGESIZE */
-    {
-      if (NumOfSingle > count) /* (NumByteToWrite + WriteAddr) > sFLASH_PAGESIZE */
-      {
-        temp = NumOfSingle - count;
-
-        sFLASH_WritePage(pBuffer, WriteAddr, count);
-        WriteAddr +=  count;
-        pBuffer += count;
-
-        sFLASH_WritePage(pBuffer, WriteAddr, temp);
-      }
-      else
-      {
-        sFLASH_WritePage(pBuffer, WriteAddr, NumByteToWrite);
-      }
-    }
-    else /* NumByteToWrite > sFLASH_PAGESIZE */
-    {
-      NumByteToWrite -= count;
-      NumOfPage =  NumByteToWrite / sFLASH_PAGESIZE;
-      NumOfSingle = NumByteToWrite % sFLASH_PAGESIZE;
-
-      sFLASH_WritePage(pBuffer, WriteAddr, count);
-      WriteAddr +=  count;
-      pBuffer += count;
-
-      while (NumOfPage--)
-      {
-        sFLASH_WritePage(pBuffer, WriteAddr, sFLASH_PAGESIZE);
-        WriteAddr +=  sFLASH_PAGESIZE;
-        pBuffer += sFLASH_PAGESIZE;
-      }
-
-      if (NumOfSingle != 0)
-      {
-        sFLASH_WritePage(pBuffer, WriteAddr, NumOfSingle);
-      }
-    }
+    pBuffer += evenBytes;
+    WriteAddr += evenBytes;
+    sFLASH_WriteByte(WriteAddr, *pBuffer++);
   }
 }
 
@@ -298,7 +267,7 @@ void sFLASH_WriteBuffer(uint8_t* pBuffer, uint32_t WriteAddr, uint16_t NumByteTo
   * @param  NumByteToRead: number of bytes to read from the FLASH.
   * @retval None
   */
-void sFLASH_ReadBuffer(uint8_t* pBuffer, uint32_t ReadAddr, uint16_t NumByteToRead)
+void sFLASH_ReadBuffer(uint8_t* pBuffer, uint32_t ReadAddr, uint32_t NumByteToRead)
 {
   /* Select the FLASH: Chip Select low */
   sFLASH_CS_LOW();
@@ -332,7 +301,7 @@ void sFLASH_ReadBuffer(uint8_t* pBuffer, uint32_t ReadAddr, uint16_t NumByteToRe
   */
 uint32_t sFLASH_ReadID(void)
 {
-  uint32_t Temp = 0, Temp0 = 0, Temp1 = 0, Temp2 = 0;
+  uint8_t byte[3];
 
   /* Select the FLASH: Chip Select low */
   sFLASH_CS_LOW();
@@ -341,22 +310,19 @@ uint32_t sFLASH_ReadID(void)
   sFLASH_SendByte(sFLASH_CMD_RDID);
 
   /* Read a byte from the FLASH */
-  Temp0 = sFLASH_SendByte(sFLASH_DUMMY_BYTE);
+  byte[0] = sFLASH_SendByte(sFLASH_DUMMY_BYTE);
 
   /* Read a byte from the FLASH */
-  Temp1 = sFLASH_SendByte(sFLASH_DUMMY_BYTE);
+  byte[1] = sFLASH_SendByte(sFLASH_DUMMY_BYTE);
 
   /* Read a byte from the FLASH */
-  Temp2 = sFLASH_SendByte(sFLASH_DUMMY_BYTE);
+  byte[2] = sFLASH_SendByte(sFLASH_DUMMY_BYTE);
 
   /* Deselect the FLASH: Chip Select high */
   sFLASH_CS_HIGH();
 
-  Temp = (Temp0 << 16) | (Temp1 << 8) | Temp2;
-
-  return Temp;
+  return (byte[0] << 16) | (byte[1] << 8) | byte[2];
 }
-
 
 /**
   * @brief  Sends a byte through the SPI interface and return the byte received
@@ -364,7 +330,7 @@ uint32_t sFLASH_ReadID(void)
   * @param  byte: byte to send.
   * @retval The value of the received byte.
   */
-uint8_t sFLASH_SendByte(uint8_t byte)
+static uint8_t sFLASH_SendByte(uint8_t byte)
 {
   /* Loop while DR register in not empty */
   while (SPI_I2S_GetFlagStatus(sFLASH_SPI, SPI_I2S_FLAG_TXE) == RESET);
@@ -384,7 +350,7 @@ uint8_t sFLASH_SendByte(uint8_t byte)
   * @param  None
   * @retval None
   */
-void sFLASH_WriteEnable(void)
+static void sFLASH_WriteEnable(void)
 {
   /* Select the FLASH: Chip Select low */
   sFLASH_CS_LOW();
@@ -401,7 +367,7 @@ void sFLASH_WriteEnable(void)
   * @param  None
   * @retval None
   */
-void sFLASH_WriteDisable(void)
+static void sFLASH_WriteDisable(void)
 {
   /* Select the FLASH: Chip Select low */
   sFLASH_CS_LOW();
@@ -419,7 +385,7 @@ void sFLASH_WriteDisable(void)
   * @param  None
   * @retval None
   */
-void sFLASH_WaitForWriteEnd(void)
+static void sFLASH_WaitForWriteEnd(void)
 {
   uint8_t flashstatus = 0;
 

--- a/SPARK_Firmware_Driver/src/sst25vf_spi.c
+++ b/SPARK_Firmware_Driver/src/sst25vf_spi.c
@@ -237,7 +237,7 @@ void sFLASH_WriteBuffer(uint8_t *pBuffer, uint32_t WriteAddr, uint32_t NumByteTo
 
   /* If write starts at an odd address, need to use single byte write
    * to write the first address. */
-  if (WriteAddr & 0x1 == 0x1)
+  if ((WriteAddr & 0x1) == 0x1)
   {
     sFLASH_WriteByte(WriteAddr, *pBuffer++);
     ++WriteAddr;


### PR DESCRIPTION
General cleanups to the sFLASH driver that fixes bugs in the existing driver if starting a write at an odd flash address and/or writing an odd number of bytes. There is also a modest improvement in code space utilization and slight speedup when writing > 4K bytes in a single write.

Test routines are available on mattande/core-firmware@4521ec1bd5bab6a5d1e236d84277c5004e83c5a2
- Expose only sFLASH_WriteBuffer(), sFLASH_ReadBuffer, sFLASH_Init,
  sFLASH_EraseSector() and sFLASH_EraseBulk() as these are the only
  functions external users should be calling.
- Add extern for binding in C++
- Note that there is no restriction on using auto address increment
  when the address crosses multiple pages
- Rewrite sFLASH_WriteBuffer() to correctly handle writing odd
  number of bytes and/or starting on an odd address
