### PR TITLE
Moves the system 1 ms timer to the common-lib

### DIFF
--- a/SPARK_Firmware_Driver/inc/hw_config.h
+++ b/SPARK_Firmware_Driver/inc/hw_config.h
@@ -101,7 +101,7 @@ typedef enum
 /* Length in bytes of DER-encoded 1024-bit RSA private key */
 #define EXTERNAL_FLASH_CORE_PRIVATE_KEY_LENGTH		(612)
 
-/* Bootloader Flash Pages that needs to be protected: 0x08000000 � 0x08003FFF */
+/* Bootloader Flash Pages that needs to be protected: 0x08000000 - 0x08003FFF */
 #define BOOTLOADER_FLASH_PAGES		( FLASH_WRProt_Pages0to3	\
 									| FLASH_WRProt_Pages4to7	\
 									| FLASH_WRProt_Pages8to11	\

--- a/SPARK_Firmware_Driver/inc/hw_config.h
+++ b/SPARK_Firmware_Driver/inc/hw_config.h
@@ -101,7 +101,7 @@ typedef enum
 /* Length in bytes of DER-encoded 1024-bit RSA private key */
 #define EXTERNAL_FLASH_CORE_PRIVATE_KEY_LENGTH		(612)
 
-/* Bootloader Flash Pages that needs to be protected: 0x08000000 – 0x08003FFF */
+/* Bootloader Flash Pages that needs to be protected: 0x08000000 ï¿½ 0x08003FFF */
 #define BOOTLOADER_FLASH_PAGES		( FLASH_WRProt_Pages0to3	\
 									| FLASH_WRProt_Pages4to7	\
 									| FLASH_WRProt_Pages8to11	\
@@ -140,6 +140,10 @@ void NVIC_Configuration(void);
 void SysTick_Configuration(void);
 void Delay(__IO uint32_t nTime);
 void Delay_Microsecond(__IO uint32_t uSec);
+
+typedef uint32_t system_tick_t;
+void System1MsTick(void) __attribute__ ((weak));
+system_tick_t GetSystem1MsTick(void);
 
 #if defined (USE_SPARK_CORE_V02)
 void RTC_Configuration(void);

--- a/SPARK_Firmware_Driver/src/hw_config.c
+++ b/SPARK_Firmware_Driver/src/hw_config.c
@@ -1734,3 +1734,16 @@ void Get_Unique_Device_ID(uint8_t *Device_ID)
   *Device_ID++ = (uint8_t)((Device_IDx & 0xFF0000) >> 16);
   *Device_ID = (uint8_t)((Device_IDx & 0xFF000000) >> 24);
 }
+
+static volatile system_tick_t system_1ms_tick = 0;
+
+void System1MsTick(void)
+{
+   system_1ms_tick++;
+}
+
+system_tick_t GetSystem1MsTick()
+{
+ return system_1ms_tick;
+}
+


### PR DESCRIPTION
Moves the system 1 ms timer to on common-lib . (For later usage from the common lib  of a 1ms timmer without any external dependency)
Makes consistent the type of the systems 1 ms time  system_tick_t
