### PR TITLE
Remove unused function now that debounce time is reset automatically

### DIFF
--- a/SPARK_Firmware_Driver/inc/hw_config.h
+++ b/SPARK_Firmware_Driver/inc/hw_config.h
@@ -174,7 +174,6 @@ void BUTTON_Init(Button_TypeDef Button, ButtonMode_TypeDef Button_Mode);
 void BUTTON_EXTI_Config(Button_TypeDef Button, FunctionalState NewState);
 uint8_t BUTTON_GetState(Button_TypeDef Button);
 uint16_t BUTTON_GetDebouncedTime(Button_TypeDef Button);
-void BUTTON_ResetDebouncedState(Button_TypeDef Button);
 
 /* CC3000 Hardware related methods */
 void CC3000_WIFI_Init(void);

--- a/SPARK_Firmware_Driver/src/hw_config.c
+++ b/SPARK_Firmware_Driver/src/hw_config.c
@@ -782,11 +782,6 @@ uint16_t BUTTON_GetDebouncedTime(Button_TypeDef Button)
 	return BUTTON_DEBOUNCED_TIME[Button];
 }
 
-void BUTTON_ResetDebouncedState(Button_TypeDef Button)
-{
-	BUTTON_DEBOUNCED_TIME[Button] = 0;
-}
-
 /**
  * @brief  Initialize the CC3000 - CS and ENABLE lines.
  * @param  None


### PR DESCRIPTION
This pull request is related to this one in Core-Firmware https://github.com/spark/core-firmware/pull/135
