### PR TITLE
Improved FLASH_Update() method - make OTA Update more reliable

### DIFF
--- a/SPARK_Firmware_Driver/inc/hw_config.h
+++ b/SPARK_Firmware_Driver/inc/hw_config.h
@@ -236,7 +236,7 @@ void FLASH_Backup(uint32_t sFLASH_Address);
 void FLASH_Restore(uint32_t sFLASH_Address);
 /* External Flash Helper routines */
 void FLASH_Begin(uint32_t sFLASH_Address);
-bool FLASH_Update(uint8_t *pBuffer, uint32_t bufferSize);
+uint16_t FLASH_Update(uint8_t *pBuffer, uint32_t bufferSize);
 void FLASH_End(void);
 void FLASH_Read_ServerAddress(ServerAddress *server_addr);
 void FLASH_Read_ServerPublicKey(uint8_t *keyBuffer);

--- a/SPARK_Firmware_Driver/inc/hw_config.h
+++ b/SPARK_Firmware_Driver/inc/hw_config.h
@@ -236,7 +236,7 @@ void FLASH_Backup(uint32_t sFLASH_Address);
 void FLASH_Restore(uint32_t sFLASH_Address);
 /* External Flash Helper routines */
 void FLASH_Begin(uint32_t sFLASH_Address);
-void FLASH_Update(uint8_t *pBuffer, uint32_t bufferSize);
+bool FLASH_Update(uint8_t *pBuffer, uint32_t bufferSize);
 void FLASH_End(void);
 void FLASH_Read_ServerAddress(ServerAddress *server_addr);
 void FLASH_Read_ServerPublicKey(uint8_t *keyBuffer);


### PR DESCRIPTION
Use with latest core-communication-lib(branch: bug-fixes) and core-firmware(branch: bug-fixes) 
In FLASH_Update(), the written data buffer is read back and the verified result flag is now returned.
