### PR TITLE
RAM optimization and clean up of sFLASH_write function

### DIFF
--- a/CC3000_Host_Driver/security.c
+++ b/CC3000_Host_Driver/security.c
@@ -85,7 +85,6 @@ const UINT8 Rcon[11] = {
 		0x8d, 0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80, 0x1b, 0x36};
 
 
-UINT8 expandedKey[176];
 
 //*****************************************************************************
 //
@@ -442,7 +441,7 @@ void aes_decr(UINT8 *state, UINT8 *expandedKey)
 //!
 //*****************************************************************************
 
-void aes_encrypt(UINT8 *state, UINT8 *key)
+void aes_encrypt(UINT8 *state, UINT8 *key, UINT8 expandedKey[176])
 {
 	// expand the key into 176 bytes
 	expandKey(expandedKey, key);       
@@ -466,7 +465,7 @@ void aes_encrypt(UINT8 *state, UINT8 *key)
 //!
 //*****************************************************************************
 
-void aes_decrypt(UINT8 *state, UINT8 *key)
+void aes_decrypt(UINT8 *state, UINT8 *key, UINT8 expandedKey[176])
 {
 	expandKey(expandedKey, key);       // expand the key into 176 bytes
 	aes_decr(state, expandedKey);

--- a/CC3000_Host_Driver/security.c
+++ b/CC3000_Host_Driver/security.c
@@ -85,7 +85,7 @@ const unsigned char Rcon[11] = {
   0x8d, 0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80, 0x1b, 0x36};
 
 
-unsigned char expandedKey[176];
+//unsigned char expandedKey[176];
 
 //*****************************************************************************
 //
@@ -445,7 +445,8 @@ void aes_decr(unsigned char *state, unsigned char *expandedKey)
 //*****************************************************************************
 
 void aes_encrypt(unsigned char *state,
-                 unsigned char *key)
+                 unsigned char *key,
+                 unsigned char expandedKey[176])
 {
 	// expand the key into 176 bytes
 	expandKey(expandedKey, key);       
@@ -470,7 +471,8 @@ void aes_encrypt(unsigned char *state,
 //*****************************************************************************
 
 void aes_decrypt(unsigned char *state,
-                 unsigned char *key)
+                 unsigned char *key,
+                 unsigned char expandedKey[176])
 {
     expandKey(expandedKey, key);       // expand the key into 176 bytes
     aes_decr(state, expandedKey);

--- a/CC3000_Host_Driver/security.h
+++ b/CC3000_Host_Driver/security.h
@@ -59,7 +59,8 @@ extern "C" {
 //!
 //!  @param[in]  key   AES128 key of size 16 bytes
 //!  @param[in\out] state   16 bytes of plain text and cipher text
-//!
+//!  @param[in] expandedKey temporary buffer for key
+//!    
 //!  @return  none
 //!
 //!  @brief   AES128 encryption:
@@ -69,7 +70,7 @@ extern "C" {
 //!	 
 //!
 //*****************************************************************************
-extern void aes_encrypt(UINT8 *state, UINT8 *key);
+extern void aes_encrypt(UINT8 *state, UINT8 *key, UINT8 expandedKey[176]);
 
 //*****************************************************************************
 //
@@ -77,6 +78,7 @@ extern void aes_encrypt(UINT8 *state, UINT8 *key);
 //!
 //!  @param[in]  key   AES128 key of size 16 bytes
 //!  @param[in\out] state   16 bytes of cipher text and plain text
+//!  @param[in] expandedKey temporary buffer for key
 //!
 //!  @return  none
 //!
@@ -87,7 +89,7 @@ extern void aes_encrypt(UINT8 *state, UINT8 *key);
 //!	 
 //!
 //*****************************************************************************
-extern void aes_decrypt(UINT8 *state, UINT8 *key);
+extern void aes_decrypt(UINT8 *state, UINT8 *key, UINT8 expandedKey[176]);
 
 
 //*****************************************************************************

--- a/CC3000_Host_Driver/security.h
+++ b/CC3000_Host_Driver/security.h
@@ -69,7 +69,7 @@ extern "C" {
 //!	 
 //!
 //*****************************************************************************
-extern void aes_encrypt(unsigned char *state, unsigned char *key);
+extern void aes_encrypt(unsigned char *state, unsigned char *key, unsigned char expandedKey[176]);
 
 //*****************************************************************************
 //
@@ -87,7 +87,7 @@ extern void aes_encrypt(unsigned char *state, unsigned char *key);
 //!	 
 //!
 //*****************************************************************************
-extern void aes_decrypt(unsigned char *state, unsigned char *key);
+extern void aes_decrypt(unsigned char *state, unsigned char *key, unsigned char expandedKey[176]);
 
 
 //*****************************************************************************

--- a/CC3000_Host_Driver/wlan.c
+++ b/CC3000_Host_Driver/wlan.c
@@ -1146,9 +1146,10 @@ wlan_smart_config_process()
 	
 	decKeyPtr = &profileArray[profileArray[0] + 3];
 	
-	aes_decrypt(decKeyPtr, key);
+        unsigned char expandedKey[176];
+	aes_decrypt(decKeyPtr, key, expandedKey);
 	if (profileArray[profileArray[0] + 1] > 16)
-		aes_decrypt((unsigned char *)(decKeyPtr + 16), key);
+		aes_decrypt((unsigned char *)(decKeyPtr + 16), key, expandedKey);
 	
 	if (*(unsigned char *)(decKeyPtr +31) != 0)
 	{

--- a/CC3000_Host_Driver/wlan.c
+++ b/CC3000_Host_Driver/wlan.c
@@ -1131,9 +1131,10 @@ INT32 wlan_smart_config_process()
 
 	decKeyPtr = &profileArray[profileArray[0] + 3];
 
-	aes_decrypt(decKeyPtr, key);
+        UINT8 expandedKey[176];
+	aes_decrypt(decKeyPtr, key, expandedKey);
 	if (profileArray[profileArray[0] + 1] > 16)
-		aes_decrypt((UINT8 *)(decKeyPtr + 16), key);
+		aes_decrypt((UINT8 *)(decKeyPtr + 16), key, expandedKey);
 
 	if (*(UINT8 *)(decKeyPtr +31) != 0)
 	{

--- a/SPARK_Firmware_Driver/inc/sst25vf_spi.h
+++ b/SPARK_Firmware_Driver/inc/sst25vf_spi.h
@@ -62,7 +62,7 @@ extern "C" {
 void sFLASH_Init(void);
 void sFLASH_EraseSector(uint32_t SectorAddr);
 void sFLASH_EraseBulk(void);
-void sFLASH_WriteBuffer(uint8_t *pBuffer, uint32_t WriteAddr, uint32_t NumByteToWrite);
+void sFLASH_WriteBuffer(const uint8_t *pBuffer, uint32_t WriteAddr, uint32_t NumByteToWrite);
 void sFLASH_ReadBuffer(uint8_t *pBuffer, uint32_t ReadAddr, uint32_t NumByteToRead);
 uint32_t sFLASH_ReadID(void);
 

--- a/SPARK_Firmware_Driver/src/sst25vf_spi.c
+++ b/SPARK_Firmware_Driver/src/sst25vf_spi.c
@@ -29,7 +29,7 @@
 
 /* Local function forward declarations ---------------------------------------*/
 static void sFLASH_WriteByte(uint32_t WriteAddr, uint8_t byte);
-static void sFLASH_WriteBytes(uint8_t *pBuffer, uint32_t WriteAddr, uint32_t NumByteToWrite);
+static void sFLASH_WriteBytes(const uint8_t *pBuffer, uint32_t WriteAddr, uint32_t NumByteToWrite);
 static void sFLASH_WriteEnable(void);
 static void sFLASH_WriteDisable(void);
 static void sFLASH_WaitForWriteEnd(void);
@@ -170,7 +170,7 @@ static void sFLASH_WriteByte(uint32_t WriteAddr, uint8_t byte)
   * @param  NumByteToWrite: number of bytes to write to the FLASH, must be even.
   * @retval None
   */
-static void sFLASH_WriteBytes(uint8_t *pBuffer, uint32_t WriteAddr, uint32_t NumByteToWrite)
+static void sFLASH_WriteBytes(const uint8_t *pBuffer, uint32_t WriteAddr, uint32_t NumByteToWrite)
 {
   /* Enable the write access to the FLASH */
   sFLASH_WriteEnable();
@@ -231,7 +231,7 @@ static void sFLASH_WriteBytes(uint8_t *pBuffer, uint32_t WriteAddr, uint32_t Num
   * @param  NumByteToWrite: number of bytes to write to the FLASH.
   * @retval None
   */
-void sFLASH_WriteBuffer(uint8_t *pBuffer, uint32_t WriteAddr, uint32_t NumByteToWrite)
+void sFLASH_WriteBuffer(const uint8_t *pBuffer, uint32_t WriteAddr, uint32_t NumByteToWrite)
 {
   uint32_t evenBytes;
 


### PR DESCRIPTION
The RAM optimization frees 176 bytes by allocating the static expandedKey buffer on the stack. As you see, it was only used in one place. 

The sFLASH_Write change was just a little tidy up to make the source buffer `const` - since writing doesn't change that data. 
