### PR TITLE
separate out hardware-independent LED code

### DIFF
--- a/SPARK_Firmware_Driver/inc/hw_config.h
+++ b/SPARK_Firmware_Driver/inc/hw_config.h
@@ -34,6 +34,7 @@
 #include "sst25vf_spi.h"
 #include "cc3000_common.h"
 #include "usb_type.h"
+#include "rgbled.h"
 
 enum SpiBusOwner {
     BUS_OWNER_NONE = 0,
@@ -57,11 +58,6 @@ typedef enum
 {
 	D0 = 0, D1 = 1, D2 = 2, D3 = 3, D4 = 4, D5 = 5, D6 = 6, D7 = 7
 } DIO_TypeDef;
-
-typedef enum
-{
-	LED1 = 0, LED2 = 1, LED3 = 2, LED4 = 3, LED3_LED4_LED2 = 231
-} Led_TypeDef;
 
 typedef enum
 {
@@ -133,20 +129,6 @@ typedef struct ServerAddress {
 									| FLASH_WRProt_Pages8to11	\
 									| FLASH_WRProt_Pages12to15 )
 
-//Extended LED Types
-#define LED_RGB				LED3_LED4_LED2
-#define LED_USER			LED1
-
-//RGB Basic Colors
-#define RGB_COLOR_RED		0xFF0000
-#define RGB_COLOR_GREEN		0x00FF00
-#define RGB_COLOR_BLUE		0x0000FF
-#define RGB_COLOR_YELLOW	0xFFFF00
-#define RGB_COLOR_CYAN		0x00FFFF
-#define RGB_COLOR_MAGENTA	0xFF00FF
-#define RGB_COLOR_WHITE		0xFFFFFF
-#define RGB_COLOR_ORANGE  0xFF6000
-
 /* USB Config : IMR_MSK */
 /* mask defining which events has to be handled */
 /* by the device application software */
@@ -184,18 +166,6 @@ DIO_Error_TypeDef DIO_SetState(DIO_TypeDef Dx, DIO_State_TypeDef State);
 
 void UI_Timer_Configure(void);
 
-void LED_SetRGBColor(uint32_t RGB_Color);
-void LED_SetSignalingColor(uint32_t RGB_Color);
-void LED_Signaling_Start(void);
-void LED_Signaling_Stop(void);
-void LED_Signaling_Override(void) __attribute__ ((weak));
-void LED_SetBrightness(uint8_t brightness); /* 0 = off, 255 = full brightness */
-
-void LED_Init(Led_TypeDef Led);
-void LED_On(Led_TypeDef Led);
-void LED_Off(Led_TypeDef Led);
-void LED_Toggle(Led_TypeDef Led);
-void LED_Fade(Led_TypeDef Led);
 
 void BUTTON_Init(Button_TypeDef Button, ButtonMode_TypeDef Button_Mode);
 void BUTTON_EXTI_Config(Button_TypeDef Button, FunctionalState NewState);

--- a/SPARK_Firmware_Driver/src/build.mk
+++ b/SPARK_Firmware_Driver/src/build.mk
@@ -9,6 +9,7 @@ TARGET_SPARK_SRC_PATH = $(TARGET_SPARK_PATH)/src
 
 # Add tropicssl include to all objects built for this target
 INCLUDE_DIRS += $(TARGET_SPARK_PATH)/inc
+INCLUDE_DIRS += SPARK_Services/inc
 
 # C source files included in this build.
 CSRC += $(TARGET_SPARK_SRC_PATH)/cc3000_spi.c

--- a/SPARK_Services/inc/rgbled.h
+++ b/SPARK_Services/inc/rgbled.h
@@ -36,6 +36,7 @@ void LED_Off(Led_TypeDef Led);
 void LED_Toggle(Led_TypeDef Led);
 void LED_Fade(Led_TypeDef Led);
 
+uint8_t Get_LED_Brightness();
 // Hardware interface
 
 /**

--- a/SPARK_Services/inc/rgbled.h
+++ b/SPARK_Services/inc/rgbled.h
@@ -1,0 +1,56 @@
+
+#ifndef RGBLED_H
+#define	RGBLED_H
+
+typedef enum
+{
+	LED1 = 0, LED2 = 1, LED3 = 2, LED4 = 3, LED3_LED4_LED2 = 231
+} Led_TypeDef;
+
+
+//Extended LED Types
+#define LED_RGB				LED3_LED4_LED2
+#define LED_USER			LED1
+
+//RGB Basic Colors
+#define RGB_COLOR_RED		0xFF0000
+#define RGB_COLOR_GREEN		0x00FF00
+#define RGB_COLOR_BLUE		0x0000FF
+#define RGB_COLOR_YELLOW	0xFFFF00
+#define RGB_COLOR_CYAN		0x00FFFF
+#define RGB_COLOR_MAGENTA	0xFF00FF
+#define RGB_COLOR_WHITE		0xFFFFFF
+#define RGB_COLOR_ORANGE  0xFF6000
+
+
+void LED_SetRGBColor(uint32_t RGB_Color);
+void LED_SetSignalingColor(uint32_t RGB_Color);
+void LED_Signaling_Start(void);
+void LED_Signaling_Stop(void);
+void LED_Signaling_Override(void) __attribute__ ((weak));
+void LED_SetBrightness(uint8_t brightness); /* 0 = off, 255 = full brightness */
+void LED_RGB_Get(uint8_t* rgb);
+void LED_Init(Led_TypeDef Led);
+void LED_On(Led_TypeDef Led);
+void LED_Off(Led_TypeDef Led);
+void LED_Toggle(Led_TypeDef Led);
+void LED_Fade(Led_TypeDef Led);
+
+// Hardware interface
+
+/**
+ * Directly set the color of the RGB led.
+ */
+void Set_RGB_LED(uint16_t* data);
+extern void Set_RGB_LED_Values(uint16_t r, uint16_t g, uint16_t b);
+
+extern void Get_RGB_LED_Values(uint16_t* rgb);
+
+extern void Set_User_LED(uint8_t state);
+extern void Toggle_User_LED();
+
+extern uint16_t Get_RGB_LED_Max_Value();
+
+
+#endif	/* RGBLED_H */
+

--- a/SPARK_Services/readme.md
+++ b/SPARK_Services/readme.md
@@ -1,0 +1,1 @@
+This folder contains hardware-neutral services. In principle these could be part of a separate repo, but are kept here to avoid users needing to clone another repo.

--- a/SPARK_Services/src/build.mk
+++ b/SPARK_Services/src/build.mk
@@ -1,0 +1,19 @@
+# This file is a makefile included from the top level makefile which
+# defines the sources built for the target.
+
+# Define the prefix to this directory. 
+# Note: The name must be unique within this build and should be
+#       based on the root of the project
+TARGET_SPARK_SERVICES_PATH = SPARK_Services
+TARGET_SPARK_SERVICES_SRC_PATH = $(TARGET_SPARK_SERVICES_PATH)/src
+
+INCLUDE_DIRS += $(TARGET_SPARK_SERVICES_SRC_PATH)/inc
+
+CSRC += $(TARGET_SPARK_SERVICES_SRC_PATH)/rgbled.c
+
+# C++ source files included in this build.
+CPPSRC +=
+
+# ASM source files included in this build.
+ASRC +=
+

--- a/SPARK_Services/src/rgbled.c
+++ b/SPARK_Services/src/rgbled.c
@@ -51,15 +51,24 @@ void LED_SetBrightness(uint8_t brightness)
     LED_RGB_BRIGHTNESS = brightness;
 }
 
+uint8_t Get_LED_Brightness() 
+{
+    return LED_RGB_BRIGHTNESS;
+}
+
+/**
+ * Sets the color on the RGB led. The color is adjusted for brightness.
+ * @param color
+ */
+
 void Set_RGB_LED_Color(uint32_t color) {
     uint16_t ccr[3];
     Set_CCR_Color(color, ccr);
     Set_RGB_LED(ccr);
 }
 
-
 uint16_t scale_fade(uint8_t step, uint16_t value) {
-    return (uint16_t)(((uint32_t) value) * step) / (NUM_LED_FADE_STEPS - 1);
+    return (uint16_t)((((uint32_t) value) * step) / (NUM_LED_FADE_STEPS - 1));
 }
 
 void Set_RGB_LED_Scale(uint8_t step, uint32_t color) {
@@ -134,6 +143,7 @@ void LED_Off(Led_TypeDef Led)
 void LED_Toggle(Led_TypeDef Led)
 {
     uint32_t color;
+    uint16_t rgb[3];
     switch(Led)
     {
     case LED_USER:
@@ -143,12 +153,13 @@ void LED_Toggle(Led_TypeDef Led)
         break;
 
     case LED_RGB://LED_SetRGBColor() and LED_On() should be called first for this Case        
+        
         color = LED_RGB_OVERRIDE ? lastSignalColor : lastRGBColor;
-        if (color)
+        Get_RGB_LED_Values(rgb);
+        if (rgb[0] | rgb[1] | rgb[2])
             Set_RGB_LED_Values(0,0,0);
-        else {
-            Set_RGB_LED_Color(color);
-        }
+        else
+            Set_RGB_LED_Color(color);        
         break;
     }
 }
@@ -183,7 +194,7 @@ void LED_RGB_Get(uint8_t* rgb) {
     uint16_t values[3];
     Get_RGB_LED_Values(values);
     for (i=0; i<3; i++) {
-        rgb[i] = (values[i]*Get_RGB_LED_Max_Value())>>8;
+        rgb[i] = (uint8_t)(((uint32_t)(values[i])<<8)/(Get_RGB_LED_Max_Value()));
     }
 }
 

--- a/SPARK_Services/src/rgbled.c
+++ b/SPARK_Services/src/rgbled.c
@@ -1,0 +1,192 @@
+
+#include <stdint.h>
+#include "rgbled.h"
+
+uint8_t LED_RGB_OVERRIDE = 0;
+uint8_t LED_RGB_BRIGHTNESS = 96;
+uint32_t lastSignalColor = 0;
+uint32_t lastRGBColor = 0;
+
+/* Led Fading. */
+#define NUM_LED_FADE_STEPS 100 /* Called at 100Hz, fade over 1 second. */
+static uint8_t led_fade_step = NUM_LED_FADE_STEPS - 1;
+static uint8_t led_fade_direction = -1; /* 1 = rising, -1 = falling. */
+
+uint16_t ccr_scale(uint8_t color) {
+    return (uint16_t)((((uint32_t)(color)) * LED_RGB_BRIGHTNESS * Get_RGB_LED_Max_Value()) >> 16);
+}
+
+void Set_CCR_Color(uint32_t RGB_Color, uint16_t* ccr) {
+    ccr[0] = ccr_scale((RGB_Color>>16) & 0xFF);
+    ccr[1] = ccr_scale((RGB_Color>>8) & 0xFF);
+    ccr[2] = ccr_scale(RGB_Color & 0xFF);
+}
+
+void LED_SetRGBColor(uint32_t RGB_Color)
+{
+    lastRGBColor = RGB_Color;
+}
+
+void LED_SetSignalingColor(uint32_t RGB_Color)
+{
+    lastSignalColor = RGB_Color;
+}
+
+void LED_Signaling_Start(void)
+{
+    LED_RGB_OVERRIDE = 1;
+
+    LED_Off(LED_RGB);
+}
+
+void LED_Signaling_Stop(void)
+{
+    LED_RGB_OVERRIDE = 0;
+
+    LED_On(LED_RGB);
+}
+
+void LED_SetBrightness(uint8_t brightness)
+{
+    LED_RGB_BRIGHTNESS = brightness;
+}
+
+void Set_RGB_LED_Color(uint32_t color) {
+    uint16_t ccr[3];
+    Set_CCR_Color(color, ccr);
+    Set_RGB_LED(ccr);
+}
+
+
+uint16_t scale_fade(uint8_t step, uint16_t value) {
+    return (uint16_t)(((uint32_t) value) * step) / (NUM_LED_FADE_STEPS - 1);
+}
+
+void Set_RGB_LED_Scale(uint8_t step, uint32_t color) {
+    int i;
+    uint16_t ccr[3];
+    Set_CCR_Color(color, ccr);
+    for (i=0; i<3; i++)
+        ccr[i] = scale_fade(step, ccr[i]);
+    Set_RGB_LED(ccr);
+}
+
+
+/**
+  * @brief  Turns selected LED On.
+  * @param  Led: Specifies the Led to be set on.
+  *   This parameter can be one of following parameters:
+  *     @arg LED1, LED2, LED_USER, LED_RGB
+  * @retval None
+  */
+void LED_On(Led_TypeDef Led)
+{
+    switch(Led)
+    {
+    case LED_USER:
+        Set_User_LED(1);
+        break;
+
+    case LED_RGB:	//LED_SetRGBColor() should be called first for this Case        
+        Set_RGB_LED_Color(LED_RGB_OVERRIDE ? lastSignalColor : lastRGBColor);
+        led_fade_step = NUM_LED_FADE_STEPS - 1;
+        led_fade_direction = -1; /* next fade is falling */
+        break;
+    default:
+        break;
+    }
+}
+
+/**
+  * @brief  Turns selected LED Off.
+  * @param  Led: Specifies the Led to be set off.
+  *   This parameter can be one of following parameters:
+  *     @arg LED1, LED2, LED_USER, LED_RGB
+  * @retval None
+  */
+void LED_Off(Led_TypeDef Led)
+{
+    switch(Led)
+    {
+    case LED_USER:
+        Set_User_LED(0);
+        break;
+
+    case LED_RGB:
+        Set_RGB_LED_Values(0,0,0);
+        led_fade_step = 0;
+        led_fade_direction = 1; /* next fade is rising. */
+        break;
+    default:
+        break;
+    }
+}
+
+
+
+/**
+  * @brief  Toggles the selected LED.
+  * @param  Led: Specifies the Led to be toggled.
+  *   This parameter can be one of following parameters:
+  *     @arg LED1, LED2, LED_USER, LED_RGB
+  * @retval None
+  */
+void LED_Toggle(Led_TypeDef Led)
+{
+    uint32_t color;
+    switch(Led)
+    {
+    case LED_USER:
+        Toggle_User_LED();
+        break;
+    default:
+        break;
+
+    case LED_RGB://LED_SetRGBColor() and LED_On() should be called first for this Case        
+        color = LED_RGB_OVERRIDE ? lastSignalColor : lastRGBColor;
+        if (color)
+            Set_RGB_LED_Values(0,0,0);
+        else {
+            Set_RGB_LED_Color(color);
+        }
+        break;
+    }
+}
+
+
+/**
+  * @brief  Fades selected LED.
+  * @param  Led: Specifies the Led to be set on.
+  *   This parameter can be one of following parameters:
+  *     @arg LED1, LED2, LED_RGB
+  * @retval None
+  */
+void LED_Fade(Led_TypeDef Led)
+{
+  /* Update position in fade. */
+    if (led_fade_step == 0)
+        led_fade_direction = 1; /* Switch to fade growing. */
+    else if (led_fade_step == NUM_LED_FADE_STEPS - 1)
+        led_fade_direction = -1; /* Switch to fade falling. */
+
+    led_fade_step += led_fade_direction;
+
+    if(Led == LED_RGB)
+    {
+        Set_RGB_LED_Scale(led_fade_step, LED_RGB_OVERRIDE ? lastSignalColor : lastRGBColor);
+    }
+}
+
+
+void LED_RGB_Get(uint8_t* rgb) {
+    int i=0;
+    uint16_t values[3];
+    Get_RGB_LED_Values(values);
+    for (i=0; i<3; i++) {
+        rgb[i] = (values[i]*Get_RGB_LED_Max_Value())>>8;
+    }
+}
+
+void Set_RGB_LED(uint16_t* data) {
+    Set_RGB_LED_Values(data[0], data[1], data[2]);
+}


### PR DESCRIPTION
core-common-lib has a mix of hardware specific and hardware agnostic code. I've split out the LED code that handles brightness, and sharing the LED between the system and user into a separate file. The hardware-dependent parts are made available as external functions (still in `hw_config.c`.) This separation makes it possible to unit test the RGB led management code on gcc without pulling in hardware dependent code.
